### PR TITLE
fix vscode ignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -15,10 +15,8 @@ vsc-extension-quickstart.md
 **/*.ts
 **/*.d.ts
 build/**
-pyodide/node/*.js
 pyodide/node/*.js.map
 pyodide/node/*.d.ts
-pyodide/common/*.js
 pyodide/common/*.js.map
 pyodide/common/*.d.ts
 pyodide/*.map


### PR DESCRIPTION
Otherwise the pyodide node files are not included in the bundle. 